### PR TITLE
Search for SNR namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The command above will create a local directory with a dump of the operator's st
 Note that this command will only get data related to the operator's part of the OpenShift cluster.
 
 You will get a dump of:
-- the namespace to which NodeHealthCheck and Poison Pill Operators are deployed, including logs
-- NHC and PP related CRs
+- the namespace to which NodeHealthCheck and Self Node Remediation Operators are deployed, including logs
+- NHC and SNR related CRs
 - Nodes
 
 In order to get data about other parts of the cluster (not specific to medik8s) you should

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -11,17 +11,17 @@ named_resources=()
 # Resource groups list, eg. pods
 group_resources=()
 
-# NHC and PP namespaces
+# NHC and SNR namespaces
 NHC_NS=$(oc get subs -A --field-selector=metadata.name=node-healthcheck-operator -o jsonpath='{.items[*].metadata.namespace}')
 if [ -n "$NHC_NS" ]
 then
   named_resources+=(ns/${NHC_NS})
 fi
 
-PP_NS=$(oc get subs -A --field-selector=metadata.name=poison-pill-manager -o jsonpath='{.items[*].metadata.namespace}')
-if [ -n "$PP_NS" ] && [ "${PP_NS}" != "${NHC_NS}" ]
+SNR_NS=$(oc get subs -A --field-selector=metadata.name=self-node-remediation -o jsonpath='{.items[*].metadata.namespace}')
+if [ -n "$SNR_NS" ] && [ "${SNR_NS}" != "${NHC_NS}" ]
 then
-  named_resources+=(ns/${PP_NS})
+  named_resources+=(ns/${SNR_NS})
 fi
 
 # Medik8s pods


### PR DESCRIPTION
Since Self Node Remediation namespace (SNR) is replacing Poison Pill, thus we should look for SNR namespace rather than PP.