### PR TITLE
Update must-gather image to v4.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-must-gather:4.10 as builder
+FROM quay.io/openshift/origin-must-gather:4.11 as builder
 
 FROM quay.io/centos/centos:stream8
 RUN dnf install rsync -y


### PR DESCRIPTION
Similar to PR for updating NMO's must-gather base image to  v4.11.0 https://github.com/medik8s/node-maintenance-operator/pull/43