### PR TITLE
Get version from image - must-gather

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY --from=builder /usr/bin/oc /usr/bin/oc
 
 # Save original gather script
 COPY --from=builder /usr/bin/gather /usr/bin/gather_original
-COPY --from=builder /usr/bin/version /usr/bin/version
+COPY --from=builder /usr/bin/version /usr/bin/version_original
 
 # Copy all collection scripts to /usr/bin
 COPY collection-scripts/* /usr/bin/

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -2,8 +2,9 @@
 
 # generate /must-gather/version file
 . version
-echo "medik8s/must-gather" > /must-gather/version
-version >> /must-gather/version
+echo "medik8s/must-gather" > /must-gather/version # imageName - Source repo identifier
+version >> /must-gather/version # imageVersion  - Build version
+imageId >> /must-gather/version # imageID  -  repository@digest          
 
 # Named resource list, eg. ns/openshift-config
 named_resources=()

--- a/collection-scripts/version
+++ b/collection-scripts/version
@@ -1,25 +1,23 @@
 #!/usr/bin/env bash
+export IMAGE=$( oc status | grep '^pod')
 
 function version() {
   # get version from image (major.minor.micro, e.g. v4.11.0)
-  version=v$( \
-    oc status | grep '^pod' | \
-    sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' \
-  )
-  # if version not found, fallback to imageID
-  [ -z "${version}" ] && version=$(oc status | grep '^pod.*runs' | sed -r -e 's/^pod.*runs //')
+  version=v$(sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' <<< $IMAGE)
 
-  # if version still not found, use Unknown
-  [ -z "${version}" ] && version="Unknown"
+  # if version is still not found, use 0.0.0-unknown
+  [ -z "${version}" ] && version="0.0.0-unknown"
+
   echo ${version}
 }
 
 function imageId() {
-   # get imageId (e.g. repository@digest )
-  imageId=$(oc status | grep '^pod' | sed -r -e 's/^pod.*runs //' | awk '{print $2}')
+  # get image id (e.g. repository@digest )
+  imageId=$(sed -r -e 's/^pod.*runs //' <<< $IMAGE | awk '{print $2}')
 
-  # if imageId is not found, use Unknown
-  [ -z "${imageId}" ] && imageId="Unknown"
+  # if image_id is not found, use Unknown
+  [ -z "${imageId}" ] && imageId="Unknown-Image"
+
 echo ${imageId}
 
 }

--- a/collection-scripts/version
+++ b/collection-scripts/version
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 function version() {
-  # get version from image (major.minor.micro, e.g. 4.11.0)
-  version=$( \
+  # get version from image (major.minor.micro, e.g. v4.11.0)
+  version=v$( \
     oc status | grep '^pod' | \
     sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' \
   )
@@ -12,4 +12,14 @@ function version() {
   # if version still not found, use Unknown
   [ -z "${version}" ] && version="Unknown"
   echo ${version}
+}
+
+function imageId() {
+   # get imageId (e.g. repository@digest )
+  imageId=$(oc status | grep '^pod' | sed -r -e 's/^pod.*runs //' | awk '{print $2}')
+
+  # if imageId is not found, use Unknown
+  [ -z "${imageId}" ] && imageId="Unknown"
+echo ${imageId}
+
 }

--- a/collection-scripts/version
+++ b/collection-scripts/version
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+function version() {
+  # get version from image (major.minor.micro, e.g. 4.11.0)
+  version=$( \
+    oc status | grep '^pod' | \
+    sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' \
+  )
+  # if version not found, fallback to imageID
+  [ -z "${version}" ] && version=$(oc status | grep '^pod.*runs' | sed -r -e 's/^pod.*runs //')
+
+  # if version still not found, use Unknown
+  [ -z "${version}" ] && version="Unknown"
+  echo ${version}
+}


### PR DESCRIPTION
According to the [must-gather enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/oc/must-gather.md#must-gather-images), there is a version file that indicates the product (first line) and the version (second line).

Currently the printed version is only in y.z format, due to regular expression, when y and z are one digit each. Resulting in "0.4" version for `https://registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v0.4.0`, rather than "0.0.4".

Fix bug https://issues.redhat.com/browse/ECOPROJECT-982