### PR TITLE
Support OLMv1 API for getting Operator's installed namespaces

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -21,16 +21,32 @@ operators=(
     fence-agents-remediation
 )
 for OP_NAME in "${operators[@]}"; do
-    # get namespaces of subscriptions, there can be multiple per operator!
-    OP_NAMESPACES=($(oc get subscriptions.operators.coreos.com -A -o=json | jq --raw-output ".items[] | select(.spec.name | contains(\"${OP_NAME}\")) | .metadata.namespace"))
-    [[ -z OP_NAMESPACES ]] && continue
+    OP_NAMESPACES=()
+    # get namespaces of subscriptions(OLM v0)
+    mapfile -t OP_NAMESPACES < <(
+        oc get subscriptions.operators.coreos.com -A -o=json \
+        | jq --raw-output ".items[] | select((.spec.name // \"\") | contains(\"${OP_NAME}\")) | .metadata.namespace"
+    )
+    # if there are no subscriptions(OLM v0), then get the namespaces from the ClusterExtension(OLM v1)
+    mapfile -t OP_NAMESPACES < <(
+        oc get clusterextension -o json \
+        | jq --raw-output ".items[] | select((.metadata.name // \"\") | contains(\"${OP_NAME}\")) | .spec.namespace"
+    )
+
+    [ ${#OP_NAMESPACES[@]} -eq 0 ] && continue
     for OP_NS in "${OP_NAMESPACES[@]}"; do
-        if ! printf "%s\n" "${named_resources[@]}" | grep -xq "ns/$OP_NS"; then
-            named_resources+=(ns/${OP_NS})
+        already_added=false
+        for existing in "${named_resources[@]}"; do
+            if [ "$existing" = "ns/${OP_NS}" ]; then
+                already_added=true
+                break
+            fi
+        done
+        if [ "$already_added" = false ]; then
+            named_resources+=("ns/${OP_NS}")
         fi
     done
 done
-
 # Medik8s pods
 # Gathering pod/podname does not collect logs, that is only done for namespaces. So no need to gather pods explicitly.
 # Leaving it here in case things change...

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -20,6 +20,8 @@ operators=(
     machine-deletion-remediation
     fence-agents-remediation
 )
+# Search for suggested namespace
+named_resources=(ns/openshift-workload-availability)
 for OP_NAME in "${operators[@]}"; do
     OP_NAMESPACES=()
     # get namespaces of subscriptions(OLM v0)

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -29,8 +29,8 @@ for OP_NAME in "${operators[@]}"; do
         oc get subscriptions.operators.coreos.com -A -o=json \
         | jq --raw-output ".items[] | select((.spec.name // \"\") | contains(\"${OP_NAME}\")) | .metadata.namespace"
     )
-    # if there are no subscriptions(OLM v0), then get the namespaces from the ClusterExtension(OLM v1)
-    mapfile -t OP_NAMESPACES < <(
+    # also gather namespaces from ClusterExtension (OLM v1) without overwriting subscription results
+    mapfile -O ${#OP_NAMESPACES[@]} -t OP_NAMESPACES < <(
         oc get clusterextension -o json \
         | jq --raw-output ".items[] | select((.metadata.name // \"\") | contains(\"${OP_NAME}\")) | .spec.namespace"
     )


### PR DESCRIPTION
<!-- Thanks for contributing to our project! We appreciate your time and effort.
Please fill out the information below to expedite the review and merge of your pull request.
-->

#### Why we need this PR
<!--
Outline the purpose of this PR, whether it's addressing a bug, implementing a new feature, or solving a specific problem.
-->
- Support OLMv1 API for getting Operator's installed namespaces
- Include suggested namespace by default when gathering Medik8s operators
- Gather namespaces from ClusterExtension (OLM v1) without overwriting subscription results

#### Changes made
<!-- Outline the specific changes made in this merge request. -->
- Include OLM Operator's installed namespaces with OLM v1 API and append them to OLM v0 list
- All of Medik8s operators CSV include a _**operatorframework.io/suggested-namespace**_ annotation with a value of `openshift-workload-availability`
- Append namespaces from ClusterExtension to the list of installed medik8s namespaces

#### Which issue(s) this PR fixes
<!--
Any reference to relevant issue(s).
Please use the following format, so that the issue will be automatically closed when this PR is merged (see https://help.github.com/articles/closing-issues-using-keywords/)

`Fixes #<issue number>`

If there is not a correspondent issue yet, you might want to open a new one yourself, describing the problem you observed.
-->
[RHWA-448](https://issues.redhat.com//browse/RHWA-448)

#### Test plan
<!--
Please, make sure that this PR meets all the necessary quality gates before submitting for review:

- Existing Unit and E2E tests are passing
- New features or bug fixes should be covered by new Unit and/or E2E tests.

This will help us to ensure that your changes are working as expected and will not break in the future.
 
In order to save cloud resources, we invite you to submit the PR as a draft and run a single E2E test job, e.g. adding a comment to the PR with the following message in order to run E2E test on OCP 4.15 only:

> /test 4.15-openshift-e2e

In case you are unable to verify E2E test prior to submit the PR, we suggest to use the WIP (Work In Progress) title prefix (e.g. "[WIP] <Title of the PR>"), and then follow the above mentioned manual test steps. Once the E2E job passes, you can remove the WIP prefix and request a review.
-->
