### PR TITLE
Fix shellcheck warnings in gather and version scripts

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # generate /must-gather/version file
+# shellcheck source=collection-scripts/version
 . version
 echo "medik8s/must-gather" > /must-gather/version # imageName - Source repo identifier
 version >> /must-gather/version # imageVersion  - Build version
@@ -63,11 +64,13 @@ group_resources+=(machinehealthchecks)
 
 # Medik8s CRDs
 MEDIK8S_CRDS=$(oc get crds -o jsonpath='{range .items[*]}{"crd/"}{.metadata.name}{"\n"}{end}' | grep 'medik8s' | sed -z 's/\n/ /g')
-named_resources+=(${MEDIK8S_CRDS})
+read -ra medik8s_crds_arr <<< "${MEDIK8S_CRDS}"
+named_resources+=("${medik8s_crds_arr[@]}")
 
 # Medik8s CRs
 MEDIK8S_CRS=$(oc get crds -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep 'medik8s' | sed -z 's/\n/ /g')
-group_resources+=(${MEDIK8S_CRS})
+read -ra medik8s_crs_arr <<< "${MEDIK8S_CRS}"
+group_resources+=("${medik8s_crs_arr[@]}")
 
 # Run the Collection of Resources using inspect
 oc adm inspect --dest-dir must-gather --rotated-pod-logs --all-namespaces "${named_resources[@]}"

--- a/collection-scripts/version
+++ b/collection-scripts/version
@@ -4,10 +4,14 @@ IMAGE=$( oc status | grep '^pod')
 
 function version() {
   # get version from image (major.minor.micro, e.g. v4.11.0)
-  version=v$(sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' <<< "$IMAGE")
+  local extracted
+  extracted=$(sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' <<< "$IMAGE")
 
-  # if version is still not found, use 0.0.0-unknown
-  [ -z "${version}" ] && version="0.0.0-unknown"
+  if [ -n "${extracted}" ]; then
+    version="v${extracted}"
+  else
+    version="0.0.0-unknown"
+  fi
 
   echo "${version}"
 }
@@ -19,6 +23,6 @@ function imageId() {
   # if image_id is not found, use Unknown
   [ -z "${imageId}" ] && imageId="Unknown-Image"
 
-echo "${imageId}"
+  echo "${imageId}"
 
 }

--- a/collection-scripts/version
+++ b/collection-scripts/version
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
-export IMAGE=$( oc status | grep '^pod')
+export IMAGE
+IMAGE=$( oc status | grep '^pod')
 
 function version() {
   # get version from image (major.minor.micro, e.g. v4.11.0)
-  version=v$(sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' <<< $IMAGE)
+  version=v$(sed -n -r -e 's/.*(([[:digit:]])+\.([[:digit:]])+\.([[:digit:]])+).*/\1/p' <<< "$IMAGE")
 
   # if version is still not found, use 0.0.0-unknown
   [ -z "${version}" ] && version="0.0.0-unknown"
 
-  echo ${version}
+  echo "${version}"
 }
 
 function imageId() {
   # get image id (e.g. repository@digest )
-  imageId=$(sed -r -e 's/^pod.*runs //' <<< $IMAGE | awk '{print $2}')
+  imageId=$(sed -r -e 's/^pod.*runs //' <<< "$IMAGE" | awk '{print $2}')
 
   # if image_id is not found, use Unknown
   [ -z "${imageId}" ] && imageId="Unknown-Image"
 
-echo ${imageId}
+echo "${imageId}"
 
 }


### PR DESCRIPTION
#### Why we need this PR:
The gather and version scripts have shellcheck warnings and info-level findings that prevent running `make check` with full shellcheck strictness. This is blocking Prow CI onboarding where we currently have to use `shellcheck -S error` as a workaround ([openshift/release#76653](https://github.com/openshift/release/pull/76653)).

#### Changes made:
- **gather**: Add `# shellcheck source=` directive for sourced `version` file ([SC1091](https://www.shellcheck.net/wiki/SC1091))
- **gather**: Use `read -ra` for safe array splitting instead of unquoted variable expansion ([SC2206](https://www.shellcheck.net/wiki/SC2206))
- **version**: Quote all variable expansions to prevent word splitting ([SC2086](https://www.shellcheck.net/wiki/SC2086))
- **version**: Separate `export` from assignment ([SC2155](https://www.shellcheck.net/wiki/SC2155))
- **version**: Fix indentation of `echo` inside `imageId()` function
- **version**: Fix bug where version fallback `0.0.0-unknown` never triggered — `version=v$(sed ...)` produces `"v"` on no match, making the `-z` check always false

#### Which issue(s) this PR fixes:
N/A

#### Test plan:
- `make check` (shellcheck) passes clean with no warnings
- `make docker-build` succeeds — image builds correctly