### PR TITLE
Modernize GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/post-submit.yaml
+++ b/.github/workflows/post-submit.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
#### Why we need this PR
Modernize GitHub Actions to current stable versions.

#### Changes made
- Bump `docker/login-action` from v3 to v4

#### Which issue(s) this PR fixes
Contributes to [RHWA-852](https://redhat.atlassian.net/browse/RHWA-852)

#### Test plan
- CI pre-submit passes with updated action versions