### PR TITLE
Add new team members to OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,8 +6,18 @@ aliases:
       - mshitrit
       - beekhof
       - razo7
+      - weshayutin
+      - mpryc
+      - jmontleon
+      - abrugaro
+      - eemcmullan
   code-reviewers:
       - slintes
       - mshitrit
       - beekhof
       - razo7
+      - weshayutin
+      - mpryc
+      - jmontleon
+      - abrugaro
+      - eemcmullan


### PR DESCRIPTION
## What

Add new team members as approvers and reviewers in the OWNERS_ALIASES file.

## Why

The team has grown and new members need Prow approve/review permissions.

## Changes

- Add weshayutin, mpryc, jmontleon, abrugaro, eemcmullan to approver and reviewer aliases

## Test plan

- [ ] Verify Prow recognizes the updated OWNERS (CI check passes)
- [ ] Verify new members can `/lgtm` and `/approve`

[RHWA-1332](https://redhat.atlassian.net/browse/RHWA-1332)